### PR TITLE
Make paths searchable

### DIFF
--- a/e2e/integration/search.e2e.ts
+++ b/e2e/integration/search.e2e.ts
@@ -20,6 +20,12 @@ describe('Search', () => {
       .first()
       .should('contain', 'Introduction');
 
+    getSearchInput().clear().type('uploadImage', { force: true });
+    cy.get('[role=search] [role=menuitem]')
+      .should('have.length', 1)
+      .first()
+      .should('contain', 'uploads an image');
+
     getSearchInput().type('{esc}', { force: true });
     getSearchResults().should('not.exist');
   });

--- a/src/services/SearchStore.ts
+++ b/src/services/SearchStore.ts
@@ -26,7 +26,7 @@ export class SearchStore<T> {
     const recurse = items => {
       items.forEach(group => {
         if (group.type !== 'group') {
-          this.add(group.name, group.description || '', group.id);
+          this.add(group.name, (group.description || '').concat(' ', group.path || ''), group.id);
         }
         recurse(group.items);
       });


### PR DESCRIPTION
## Enhance search feature to support `path`

- This allows easy and quick navigation for well-known end-points by `path` or keywords in a path 
- Supports existing search functionality

## Testing
Added E2E Test for the change
## Screenshots
![image](https://user-images.githubusercontent.com/107870785/187459548-7c73d3c5-d213-4266-9e01-e1ae7ffd5ff9.png)
![image](https://user-images.githubusercontent.com/107870785/187460373-9670e419-ef42-470c-86a9-0cf5e4b44336.png)
## Completed

- [ x] Code is linted
- [ x] Tested
- [ x] All new/updated code is covered with (E2E) tests


