### PR TITLE
Trim terms same way while indexing and querying

### DIFF
--- a/e2e/integration/search.e2e.ts
+++ b/e2e/integration/search.e2e.ts
@@ -20,12 +20,6 @@ describe('Search', () => {
       .first()
       .should('contain', 'Introduction');
 
-    getSearchInput().clear().type('uploadImage', { force: true });
-    cy.get('[role=search] [role=menuitem]')
-      .should('have.length', 1)
-      .first()
-      .should('contain', 'uploads an image');
-
     getSearchInput().type('{esc}', { force: true });
     getSearchResults().should('not.exist');
   });
@@ -64,5 +58,21 @@ describe('Search', () => {
     getSearchResults().should('not.exist');
     getSearchInput().type('xzss', { force: true });
     getSearchResults().should('exist').should('contain', 'No results found');
+  });
+
+  it('should allow search by path or keywords in path', () => {
+    getSearchInput().clear().type('uploadImage', { force: true });
+    cy.get('[role=search] [role=menuitem]')
+      .should('have.length', 1)
+      .first()
+      .should('contain', 'uploads an image');
+
+    getSearchInput()
+      .clear()
+      .type('/pet/{petId}/uploadImage', { force: true, parseSpecialCharSequences: false });
+    cy.get('[role=search] [role=menuitem]')
+      .should('have.length', 1)
+      .first()
+      .should('contain', 'uploads an image');
   });
 });

--- a/src/services/SearchWorker.worker.ts
+++ b/src/services/SearchWorker.worker.ts
@@ -37,7 +37,10 @@ function initEmpty() {
 
 initEmpty();
 
-const expandTerm = term => '*' + lunr.stemmer(new lunr.Token(term, {})) + '*';
+const expandTerm = term => {
+  const token = lunr.trimmer(new lunr.Token(term, {}));
+  return '*' + lunr.stemmer(token) + '*';
+};
 
 export function add<T>(title: string, description: string, meta?: T) {
   const ref = store.push(meta) - 1;


### PR DESCRIPTION
## What/Why/How?
The `trimmer` is only used at the time of indexing but not while `querying`. This results in an incorrect query generation and search does not work as expected, specifically if you're searching for a phrase/keyword with **special** characters in the beginning and/or at the end.

## Testing
Added E2E Tests. All Tests are passing
